### PR TITLE
Fix sawtooth-sdk-python build issue

### DIFF
--- a/docker/lint
+++ b/docker/lint
@@ -37,7 +37,6 @@ RUN apt-get install -y -q \
     python3-protobuf \
     python3-pyformance \
     python3-requests \
-    python3-sawtooth-signing \
     python3-secp256k1 \
     python3-toml \
     python3-yaml \


### PR DESCRIPTION
python3-sawtooth-signing is moved to sawtooth-sdk-python
remove it from list of install packages.

Signed-off-by: S m, Aruna <aruna.s.m@intel.com>