### PR TITLE
Allow additional protocols for consensus engines

### DIFF
--- a/protos/consensus.proto
+++ b/protos/consensus.proto
@@ -79,10 +79,17 @@ message ConsensusStateEntry {
 
 // Sent to connect with the validator
 message ConsensusRegisterRequest {
+  message Protocol {
+    string name = 1;
+    string version = 2;
+  }
+
   // The name of this consensus engine
   string name = 1;
   // The version of this consensus engine
   string version = 2;
+  // Any additional name/version pairs the consensus engine supports
+  repeated Protocol additional_protocols = 3;
 }
 
 message ConsensusRegisterResponse {

--- a/sawtooth_sdk/consensus/engine.py
+++ b/sawtooth_sdk/consensus/engine.py
@@ -62,3 +62,11 @@ class Engine(metaclass=abc.ABCMeta):
         Return:
             str
         '''
+
+    def additional_protocols(self):
+        '''Any additional protocol name/version pairs this engine supports.
+
+        Return:
+            List of (string, string) tuples
+        '''
+        return []

--- a/sawtooth_sdk/consensus/zmq_driver.py
+++ b/sawtooth_sdk/consensus/zmq_driver.py
@@ -102,12 +102,17 @@ class ZmqDriver(Driver):
         request = consensus_pb2.ConsensusRegisterRequest(
             name=self._engine.name(),
             version=self._engine.version(),
-        ).SerializeToString()
+        )
+
+        for (name, version) in self._engine.additional_protocols():
+            protocol = request.additional_protocols.add()
+            protocol.name = name
+            protocol.version = version
 
         while True:
             future = self._stream.send(
                 message_type=Message.CONSENSUS_REGISTER_REQUEST,
-                content=request)
+                content=request.SerializeToString())
             response = consensus_pb2.ConsensusRegisterResponse()
             response.ParseFromString(future.result(REGISTER_TIMEOUT).content)
 

--- a/tests/test_zmq_driver.py
+++ b/tests/test_zmq_driver.py
@@ -54,6 +54,9 @@ class MockEngine(Engine):
     def version(self):
         return 'test-version'
 
+    def additional_protocols(self):
+        return [('Test-Name', 'Test-Version')]
+
 
 class TestDriver(unittest.TestCase):
     def setUp(self):
@@ -131,8 +134,12 @@ class TestDriver(unittest.TestCase):
             response,
             Message.CONSENSUS_REGISTER_RESPONSE)
 
+        additional_protocols = \
+            [(p.name, p.version) for p in request.additional_protocols]
+
         self.assertEqual(request.name, 'test-name')
         self.assertEqual(request.version, 'test-version')
+        self.assertEqual(additional_protocols, [('Test-Name', 'Test-Version')])
 
         self.send_req_rep(
             consensus_pb2.ConsensusNotifyEngineActivated(),


### PR DESCRIPTION
Corresponds to sawtooth-core PR: hyperledger/sawtooth-core#2130

Adds an (optional) list of additional protocols that a consensus engine
supports as part of the registration process. These additional protocols
can be used for backwards compatiblity. If the values of the
`sawtooth.consensus.algorithm.name` and
`sawtooth.consensus.algorithm.version` settings match the name/version
of an engine or the name/version pair is in the engine's list of
additional protocols, that engine will be activated.

Signed-off-by: Logan Seeley <seeley@bitwise.io>