### PR TITLE
Add more specific exclude paths for bandit

### DIFF
--- a/bin/run_bandit
+++ b/bin/run_bandit
@@ -20,7 +20,7 @@ top_dir=$(cd $(dirname $(dirname $0)) && pwd)
 directories="
     build/*
     sawtooth_processor_test/*
-    tests/*
+    tests/sawtooth_integration/tests/*
 "
 
 if [ ! -d "$top_dir/build" ]; then


### PR DESCRIPTION
Workaround for bug reported here: https://github.com/PyCQA/bandit/issues/488

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>