### PR TITLE
Retire inactive maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @agunde406 @aludvik @boydjohnson @chenette @cianx @dcmiddle @delventhalz @dplumb94 @jjason @jsmitchell @nick-drozd @peterschwarz @rbuysse @vaporos
+*       @agunde406 @chenette @cianx @dcmiddle @dplumb94 @jsmitchell @peterschwarz @rbuysse @vaporos

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,16 +1,23 @@
+## Maintainers
+
+### Active Maintainers
 | Name | GitHub | RocketChat |
 | --- | --- | --- |
-| Adam Ludvik | aludvik | adamludvik |
 | Andi Gunderson | agunde406 | agunde |
 | Anne Chenette | chenette | achenette |
-| Boyd Johnson | boydjohnson | boydjohnson |
 | Cian Montgomery | cianx | cianx |
 | Dan Middleton | dcmiddle | Dan |
 | Darian Plumb | dplumb94 | dplumb |
 | James Mitchell | jsmitchell | jsmitchell |
-| Jamie Jason | jjason | jjason |
-| Nick Drozd | nick-drozd | drozd |
 | Peter Schwarz | peterschwarz | pschwarz |
 | Ryan Beck-Buysse | rbuysse | rbuysse |
 | Shawn Amundson | vaporos | amundson |
+
+### Retired Maintainers
+| Name | GitHub | RocketChat |
+| --- | --- | --- |
+| Adam Ludvik | aludvik | adamludvik |
+| Boyd Johnson | boydjohnson | boydjohnson |
+| Jamie Jason | jjason | jjason |
+| Nick Drozd | nick-drozd | drozd |
 | Zac Delventhal | delventhalz | zac |


### PR DESCRIPTION
The following maintainers have asked to be retired:

Adam Ludvik, Boyd Johnson, Jamie Jason, Nick Drozd and
Zac Delventhal.

As described in the Sawtooth Governance RFC changes to maintainers must be approved unanimously by the current group of maintainers.