### PR TITLE
Handle Ping requests in consensus zmq driver

### DIFF
--- a/sawtooth_sdk/consensus/zmq_driver.py
+++ b/sawtooth_sdk/consensus/zmq_driver.py
@@ -84,10 +84,14 @@ class ZmqDriver(Driver):
                     future = self._stream.receive()
                 except concurrent.futures.TimeoutError:
                     continue
+                try:
+                    result = self._process(message)
 
-                result = self._process(message)
+                    self._updates.put(result)
 
-                self._updates.put(result)
+                except exceptions.ReceiveError as err:
+                    LOGGER.warning("%s", err)
+                    continue
         except Exception:  # pylint: disable=broad-except
             LOGGER.exception("Uncaught driver exception")
 

--- a/sawtooth_sdk/consensus/zmq_driver.py
+++ b/sawtooth_sdk/consensus/zmq_driver.py
@@ -86,6 +86,9 @@ class ZmqDriver(Driver):
                     continue
                 try:
                     result = self._process(message)
+                    # if message was a ping ignore
+                    if result[0] == Message.PING_REQUEST:
+                        continue
 
                     self._updates.put(result)
 
@@ -234,6 +237,9 @@ class ZmqDriver(Driver):
 
         elif type_tag == Message.CONSENSUS_NOTIFY_ENGINE_DEACTIVATED:
             self.stop()
+            data = None
+
+        elif type_tag == Message.PING_REQUEST:
             data = None
 
         else:

--- a/tests/test_zmq_driver.py
+++ b/tests/test_zmq_driver.py
@@ -33,6 +33,8 @@ LOGGER = logging.getLogger(__name__)
 
 
 class MockEngine(Engine):
+    # Ignore invalid override pylint issues
+    # pylint: disable=invalid-overridden-method
     def __init__(self):
         self.updates = []
         self.exit = False

--- a/tests/test_zmq_driver.py
+++ b/tests/test_zmq_driver.py
@@ -25,6 +25,7 @@ import zmq
 from sawtooth_sdk.consensus.engine import Engine
 from sawtooth_sdk.consensus.zmq_driver import ZmqDriver
 from sawtooth_sdk.protobuf import consensus_pb2
+from sawtooth_sdk.protobuf import network_pb2
 from sawtooth_sdk.protobuf.validator_pb2 import Message
 
 
@@ -172,6 +173,10 @@ class TestDriver(unittest.TestCase):
         self.send_req_rep(
             consensus_pb2.ConsensusNotifyBlockCommit(),
             Message.CONSENSUS_NOTIFY_BLOCK_COMMIT)
+
+        self.send_req_rep(
+            network_pb2.PingRequest(),
+            Message.PING_REQUEST)
 
         self.assertEqual(
             [msg_type for (msg_type, data) in self.engine.updates],


### PR DESCRIPTION
The ping requests should be ignored and not break the zmq driver loop.