### PR TITLE
Pin mistune version to fix doc build error

### DIFF
--- a/ci/sawtooth-build-docs
+++ b/ci/sawtooth-build-docs
@@ -79,7 +79,7 @@ RUN echo "deb [arch=amd64] http://repo.sawtooth.me/ubuntu/ci bionic universe" >>
  && rm -rf /var/lib/apt/lists/* \
  && pip3 install \
     pylint \
-    bandit
+    bandit==1.7.1
 
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/ci/sawtooth-build-docs
+++ b/ci/sawtooth-build-docs
@@ -98,6 +98,7 @@ RUN apt-get update && apt-get install -y -q \
     && rm -rf /var/lib/apt/lists/* \
     && pip3 install \
     docutils==0.16 \
+    mistune==0.8.4 \
     sphinx==2.0.1 \
     sphinxcontrib-httpdomain \
     sphinxcontrib-openapi \

--- a/docker/bandit
+++ b/docker/bandit
@@ -26,7 +26,7 @@ RUN apt-get install -y -q \
     python3-dev \
     python3-pip \
  && pip3 install \
-    bandit \
+    bandit==1.7.1 \
     coverage --upgrade
 
 ENV PATH=$PATH:/project/sawtooth-sdk-python/bin

--- a/docker/lint
+++ b/docker/lint
@@ -44,7 +44,7 @@ RUN apt-get install -y -q \
     && pip3 install \
     pylint==2.6.2 \
     pycodestyle \
-    bandit \
+    bandit==1.7.1 \
     coverage --upgrade
 
 RUN apt-get install -y -q \


### PR DESCRIPTION
Sphinx-openapi depends on m2r which pulls in mistune without specifying a
version. Mistune has recently updated to 2.0.0 which includes some API
changes which were not backwards compatible.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>